### PR TITLE
fix(config): prevent duplicate TOML table entries on config save

### DIFF
--- a/internal/telemt_config/config.go
+++ b/internal/telemt_config/config.go
@@ -46,6 +46,11 @@ func SaveConfig(configPath, content string) (newHash string, err error) {
 	// Strip underscores from integer literals (e.g. 8_443 → 8443)
 	content = removeIntegerUnderscores(content)
 
+	// Convert inline empty tables (e.g. `key = {}`) to proper TOML sections.
+	// Telemt does not understand inline empty tables and they cause duplicate
+	// key errors when Telemt rewrites the config on hot-reload.
+	content = inlineTablesToSections(content)
+
 	// Create backup
 	timestamp := time.Now().Format("20060102-150405")
 	backupPath := fmt.Sprintf("%s.backup.%s", configPath, timestamp)
@@ -131,10 +136,6 @@ func QuickUpdate(configPath string, updates map[string]interface{}) (newHash str
 
 	// Remove underscores from integer literals (go-toml/v2 formats 8443 as 8_443)
 	cleaned := removeIntegerUnderscores(string(newContent))
-
-	// Convert inline empty tables like `key = {}` to proper TOML sections
-	// Telemt doesn't understand inline empty tables
-	cleaned = inlineTablesToSections(cleaned)
 
 	// Save
 	return SaveConfig(configPath, cleaned)


### PR DESCRIPTION
## Summary
- Move `inlineTablesToSections()` from `QuickUpdate()` into `SaveConfig()` so both raw editor and QuickUpdate paths convert inline empty tables (`key = {}`) to proper TOML sections (`[parent.key]`)
- Previously only `QuickUpdate` applied this conversion; the raw Monaco editor could persist inline empty tables that later caused duplicate key errors when Telemt hot-reloaded the config

## Root Cause
When the raw config editor saved TOML with `user_ad_tags = {}`, these passed through unchanged. After Telemt's hot-reload rewrote the config, both `key = {}` (inside `[access]`) and `[access.user_ad_tags]` (section) appeared in the same file, causing TOML parse errors.

Fixes #16

## Test plan
- [ ] Open config in raw editor with inline empty tables → verify they convert to sections on save
- [ ] Use QuickUpdate → verify same conversion works
- [ ] Verify no duplicate table headers appear after save + Telemt hot-reload
- [ ] `go build ./internal/telemt_config/` compiles
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)