### PR TITLE
feat(users): add username comment to proxy links

### DIFF
--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -81,17 +81,18 @@ interface LinkEntry {
   label: string;
 }
 
-function collectLinks(links?: UserLinks): LinkEntry[] {
+function collectLinks(links?: UserLinks, username?: string): LinkEntry[] {
   const result: LinkEntry[] = [];
   if (!links) return result;
+  const suffix = username ? `&comment=${encodeURIComponent(username)}` : '';
   if (links.tls) {
-    for (const url of links.tls) result.push({ url, label: 'TLS' });
+    for (const url of links.tls) result.push({ url: url + suffix, label: 'TLS' });
   }
   if (links.secure) {
-    for (const url of links.secure) result.push({ url, label: 'Secure' });
+    for (const url of links.secure) result.push({ url: url + suffix, label: 'Secure' });
   }
   if (links.classic) {
-    for (const url of links.classic) result.push({ url, label: 'Classic' });
+    for (const url of links.classic) result.push({ url: url + suffix, label: 'Classic' });
   }
   return result;
 }
@@ -279,7 +280,7 @@ export function UsersPage() {
                   </TableRow>
                 ) : (
                   pagedUsers.map((u) => {
-                    const allLinks = collectLinks(u.links);
+                    const allLinks = collectLinks(u.links, u.username);
                     const hasConns = u.current_connections > 0;
 
                     return (
@@ -362,7 +363,7 @@ export function UsersPage() {
             </div>
           ) : (
             pagedUsers.map((u) => {
-              const allLinks = collectLinks(u.links);
+              const allLinks = collectLinks(u.links, u.username);
               const hasConns = u.current_connections > 0;
 
               return (


### PR DESCRIPTION
## Summary
- Appends `&comment=username` to `tg://proxy` URLs in the Users page
- Telegram will display the username as the proxy label instead of the raw server address
- `encodeURIComponent` is used to safely handle usernames with special characters

## Test plan
- [ ] Open Users page in the panel
- [ ] Click a proxy link (TLS/Secure/Classic) — Telegram should show the username as the proxy name
- [ ] Verify `t.me` links also include the comment parameter
- [ ] Verify usernames with special characters are properly encoded

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)