### PR TITLE
feat: add configurable auto-update for panel and telemt

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -29,6 +29,11 @@ auth_header = "your-telemt-api-secret"
 # Docker container name (if Telemt runs in Docker)
 # container_name = "telemt"
 
+# [telemt.auto_update]
+# enabled = false
+# check_interval = "1h"  # Go duration: 5m, 30m, 1h, 6h, 24h (min: 5m)
+# auto_apply = true       # automatically install stable updates
+
 [panel]
 # Path to telemt-panel binary (default: /usr/local/bin/telemt-panel)
 # binary_path = "/usr/local/bin/telemt-panel"
@@ -36,6 +41,11 @@ auth_header = "your-telemt-api-secret"
 # service_name = "telemt-panel"
 # GitHub repository for update checks (default: amirotin/telemt_panel)
 # github_repo = "amirotin/telemt_panel"
+
+# [panel.auto_update]
+# enabled = false
+# check_interval = "1h"
+# auto_apply = false      # panel restart kills sessions, use with caution
 # Maximum number of newer/older releases shown in update selector (default: 10)
 # max_newer_releases = 10
 # max_older_releases = 10

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,6 +51,8 @@ export const panelApi = {
   get: <T>(path: string) => request<T>(PANEL_BASE, path),
   post: <T>(path: string, body?: unknown) =>
     request<T>(PANEL_BASE, path, { method: 'POST', body: body ? JSON.stringify(body) : undefined }),
+  put: <T>(path: string, body?: unknown) =>
+    request<T>(PANEL_BASE, path, { method: 'PUT', body: body ? JSON.stringify(body) : undefined }),
 };
 
 export const authApi = {

--- a/frontend/src/pages/UpdatePage.tsx
+++ b/frontend/src/pages/UpdatePage.tsx
@@ -32,6 +32,154 @@ interface ReleasesResult {
 }
 
 const PHASE_STEPS = ['checking', 'downloading', 'verifying', 'replacing', 'restarting'];
+interface AutoUpdateConfig {
+  enabled: boolean;
+  check_interval: string;
+  auto_apply: boolean;
+}
+
+interface AutoUpdateComponentState {
+  config: AutoUpdateConfig;
+  last_check: { current_version: string; latest_version: string; update_available: boolean; release_name: string } | null;
+  last_check_at: string | null;
+}
+
+interface AutoUpdateStatus {
+  panel: AutoUpdateComponentState;
+  telemt: AutoUpdateComponentState;
+}
+
+const INTERVAL_OPTIONS = [
+  { value: '5m', label: '5 минут' },
+  { value: '15m', label: '15 минут' },
+  { value: '30m', label: '30 минут' },
+  { value: '1h', label: '1 час' },
+  { value: '3h', label: '3 часа' },
+  { value: '6h', label: '6 часов' },
+  { value: '12h', label: '12 часов' },
+  { value: '24h', label: '24 часа' },
+];
+
+function AutoUpdateCard({
+  title,
+  state,
+  onSave,
+}: {
+  title: string;
+  state: AutoUpdateComponentState;
+  onSave: (config: AutoUpdateConfig) => void;
+}) {
+  const [enabled, setEnabled] = useState(state.config.enabled);
+  const [interval, setInterval] = useState(state.config.check_interval || '1h');
+  const [autoApply, setAutoApply] = useState(state.config.auto_apply);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setEnabled(state.config.enabled);
+    setInterval(state.config.check_interval || '1h');
+    setAutoApply(state.config.auto_apply);
+  }, [state.config.enabled, state.config.check_interval, state.config.auto_apply]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      onSave({ enabled, check_interval: interval, auto_apply: autoApply });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasChanges = enabled !== state.config.enabled || interval !== (state.config.check_interval || '1h') || autoApply !== state.config.auto_apply;
+
+  return (
+    <div className="bg-surface rounded-lg p-4 lg:p-5 border border-border">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs lg:text-sm font-semibold text-text-primary">{title}</h3>
+        {state.last_check_at && (
+          <span className="text-[10px] lg:text-xs text-text-secondary">
+            Последняя проверка: {new Date(state.last_check_at).toLocaleString('ru-RU')}
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-text-secondary">{enabled ? "Вкл" : "Выкл"}</span>
+          <button
+            onClick={() => setEnabled(!enabled)}
+            className={cn(
+              'relative w-10 h-5 rounded-full transition-colors',
+              enabled ? 'bg-accent' : 'bg-border'
+            )}
+          >
+            <span className={cn(
+              'absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform',
+              enabled ? 'left-5' : 'left-0.5'
+            )} />
+          </button>
+        </div>
+
+        {enabled && (
+          <>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Интервал проверки</span>
+              <select
+                value={interval}
+                onChange={(e) => setInterval(e.target.value)}
+                className="bg-background text-text-primary rounded px-2 py-1 text-sm border border-border focus:border-accent focus:outline-none"
+              >
+                {INTERVAL_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Автоустановка</span>
+              <button
+                onClick={() => setAutoApply(!autoApply)}
+                className={cn(
+                  'relative w-10 h-5 rounded-full transition-colors',
+                  autoApply ? 'bg-accent' : 'bg-border'
+                )}
+              >
+                <span className={cn(
+                  'absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform',
+                  autoApply ? 'left-5' : 'left-0.5'
+                )} />
+              </button>
+            </div>
+          </>
+        )}
+
+        {state.last_check && (
+          <div className="flex items-center gap-2 text-xs">
+            {state.last_check.update_available ? (
+              <span className="text-accent">
+                Доступно: {state.last_check.latest_version}
+              </span>
+            ) : (
+              <span className="text-success">
+                Актуально ({state.last_check.current_version})
+              </span>
+            )}
+          </div>
+        )}
+
+        {hasChanges && (
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="px-3 py-1.5 text-sm rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Сохранение...' : 'Сохранить'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 
 function VersionSelect({
   releases,
@@ -165,6 +313,33 @@ export function UpdatePage() {
   const [panelReleasesError, setPanelReleasesError] = useState('');
   const [panelShowConfirm, setPanelShowConfirm] = useState(false);
 
+  // Auto-update state
+  const [autoStatus, setAutoStatus] = useState<AutoUpdateStatus | null>(null);
+
+  // Fetch auto-update status
+  const fetchAutoStatus = async () => {
+    try {
+      const res = await panelApi.get<AutoUpdateStatus>('/auto-update/status');
+      setAutoStatus(res);
+    } catch {
+      // Ignore - feature may not be available
+    }
+  };
+
+  const handleAutoUpdateConfig = async (component: 'panel' | 'telemt', cfg: AutoUpdateConfig) => {
+    try {
+      const current = autoStatus?.[component]?.config || { enabled: false, check_interval: '1h', auto_apply: false };
+      const payload = {
+        panel: component === 'panel' ? cfg : current,
+        telemt: component === 'telemt' ? cfg : current,
+      };
+      const res = await panelApi.put<AutoUpdateStatus>('/auto-update/config', payload);
+      setAutoStatus(res);
+    } catch (e: any) {
+      alert('Ошибка: ' + (e.message || 'Не удалось сохранить настройки'));
+    }
+  };
+
   const isUpdating = status && !['idle', 'done', 'error'].includes(status.phase);
   const isPanelUpdating = panelStatus && !['idle', 'done', 'error'].includes(panelStatus.phase);
 
@@ -294,6 +469,7 @@ export function UpdatePage() {
   useEffect(() => {
     fetchReleases();
     fetchPanelReleases();
+    fetchAutoStatus();
     return () => {
       stopPolling();
       stopPanelPolling();
@@ -307,6 +483,25 @@ export function UpdatePage() {
     <div className="min-h-screen">
       <Header title="Update" onRefresh={() => { fetchReleases(); fetchPanelReleases(); }} />
       <div className="p-4 lg:p-6 space-y-4 lg:space-y-6 max-w-3xl">
+
+        {/* Auto-update settings */}
+        {autoStatus && (
+          <div className="bg-surface rounded-lg p-4 lg:p-5 border border-border">
+            <h2 className="text-xs lg:text-sm font-semibold text-text-primary mb-3 lg:mb-4">Автообновление</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 lg:gap-4">
+              <AutoUpdateCard
+                title="Panel"
+                state={autoStatus.panel}
+                onSave={(cfg) => handleAutoUpdateConfig('panel', cfg)}
+              />
+              <AutoUpdateCard
+                title="Telemt"
+                state={autoStatus.telemt}
+                onSave={(cfg) => handleAutoUpdateConfig('telemt', cfg)}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Panel Update Section */}
         <div className="bg-surface rounded-lg p-4 lg:p-5 border border-border">

--- a/internal/auto_update/auto_update.go
+++ b/internal/auto_update/auto_update.go
@@ -1,0 +1,225 @@
+package auto_update
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// CheckResult is the common result from checking for updates.
+type CheckResult struct {
+	CurrentVersion  string `json:"current_version"`
+	LatestVersion   string `json:"latest_version"`
+	UpdateAvailable bool   `json:"update_available"`
+	ReleaseName     string `json:"release_name"`
+	ReleaseURL      string `json:"release_url"`
+	PublishedAt     string `json:"published_at,omitempty"`
+	Changelog       string `json:"changelog,omitempty"`
+}
+
+// ComponentConfig holds auto-update settings for one component.
+type ComponentConfig struct {
+	Enabled       bool   `json:"enabled"`
+	CheckInterval string `json:"check_interval"` // Go duration string, e.g. "1h", "30m"
+	AutoApply     bool   `json:"auto_apply"`
+}
+
+// ParsedInterval returns the parsed duration, clamped to 5m minimum.
+func (c ComponentConfig) ParsedInterval() time.Duration {
+	if c.CheckInterval == "" {
+		return 1 * time.Hour
+	}
+	d, err := time.ParseDuration(c.CheckInterval)
+	if err != nil || d < 5*time.Minute {
+		return 1 * time.Hour
+	}
+	return d
+}
+
+// ComponentState tracks the runtime state for one component.
+type ComponentState struct {
+	Config      ComponentConfig `json:"config"`
+	LastCheck   *CheckResult    `json:"last_check,omitempty"`
+	LastCheckAt string          `json:"last_check_at,omitempty"` // RFC3339
+}
+
+// Component defines a updatable component via functions.
+type Component struct {
+	CheckFn func() (*CheckResult, error)
+	ApplyFn func(version string) error
+}
+
+// Status is the API response for GET /api/auto-update/status.
+type Status struct {
+	Panel  ComponentState `json:"panel"`
+	Telemt ComponentState `json:"telemt"`
+}
+
+// UpdateConfigRequest is the API request for PUT /api/auto-update/config.
+type UpdateConfigRequest struct {
+	Panel  ComponentConfig `json:"panel"`
+	Telemt ComponentConfig `json:"telemt"`
+}
+
+// componentRunner manages one component's auto-update ticker.
+type componentRunner struct {
+	name  string
+	cfg   ComponentConfig
+	state ComponentState
+	check func() (*CheckResult, error)
+	apply func(version string) error
+	mu    sync.Mutex
+	stopCh chan struct{}
+}
+
+// Manager manages auto-update tickers for panel and telemt.
+type Manager struct {
+	mu         sync.Mutex
+	components map[string]*componentRunner
+}
+
+// New creates a new auto-update manager.
+func New() *Manager {
+	return &Manager{
+		components: make(map[string]*componentRunner),
+	}
+}
+
+// Register adds a component to the manager and starts its ticker if enabled.
+func (m *Manager) Register(name string, comp Component, cfg ComponentConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if existing, ok := m.components[name]; ok {
+		existing.stop()
+		delete(m.components, name)
+	}
+
+	cr := &componentRunner{
+		name:  name,
+		cfg:   cfg,
+		check: comp.CheckFn,
+		apply: comp.ApplyFn,
+		state: ComponentState{Config: cfg},
+	}
+	m.components[name] = cr
+
+	if cfg.Enabled {
+		cr.start()
+	}
+}
+
+// UpdateConfig updates settings for a component and restarts its ticker.
+func (m *Manager) UpdateConfig(name string, cfg ComponentConfig) {
+	m.mu.Lock()
+	cr, ok := m.components[name]
+	m.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	cr.mu.Lock()
+	cr.cfg = cfg
+	cr.state.Config = cfg
+	cr.mu.Unlock()
+
+	cr.stop()
+	if cfg.Enabled {
+		cr.start()
+	}
+}
+
+// GetStatus returns the current state of all components.
+func (m *Manager) GetStatus() Status {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := Status{}
+	if cr, ok := m.components["panel"]; ok {
+		cr.mu.Lock()
+		s.Panel = cr.state
+		cr.mu.Unlock()
+	}
+	if cr, ok := m.components["telemt"]; ok {
+		cr.mu.Lock()
+		s.Telemt = cr.state
+		cr.mu.Unlock()
+	}
+	return s
+}
+
+// StopAll stops all component tickers.
+func (m *Manager) StopAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, cr := range m.components {
+		cr.stop()
+		delete(m.components, name)
+	}
+}
+
+func (cr *componentRunner) start() {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	cr.stopCh = make(chan struct{})
+	interval := cr.cfg.ParsedInterval()
+
+	log.Printf("[auto_update:%s] started (interval=%v, auto_apply=%v)", cr.name, interval, cr.cfg.AutoApply)
+
+	go func() {
+		cr.tick() // first check immediately
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				cr.tick()
+			case <-cr.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (cr *componentRunner) stop() {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	if cr.stopCh != nil {
+		close(cr.stopCh)
+		cr.stopCh = nil
+		log.Printf("[auto_update:%s] stopped", cr.name)
+	}
+}
+
+func (cr *componentRunner) tick() {
+	cr.mu.Lock()
+	cfg := cr.cfg
+	cr.mu.Unlock()
+
+	result, err := cr.check()
+	now := time.Now().Format(time.RFC3339)
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	if err != nil {
+		log.Printf("[auto_update:%s] check failed: %s", cr.name, err)
+		cr.state.LastCheck = nil
+		cr.state.LastCheckAt = now
+		return
+	}
+
+	cr.state.LastCheck = result
+	cr.state.LastCheckAt = now
+	log.Printf("[auto_update:%s] current=%s latest=%s update=%v",
+		cr.name, result.CurrentVersion, result.LatestVersion, result.UpdateAvailable)
+
+	if cfg.AutoApply && result.UpdateAvailable {
+		log.Printf("[auto_update:%s] auto-applying %s", cr.name, result.LatestVersion)
+		if applyErr := cr.apply(""); applyErr != nil {
+			log.Printf("[auto_update:%s] auto-apply failed: %s", cr.name, applyErr)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,10 +5,36 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"golang.org/x/crypto/bcrypt"
 )
+
+
+// AutoUpdateConfig controls automatic update checking for a component.
+type AutoUpdateConfig struct {
+	Enabled       bool   `toml:"enabled"`
+	CheckInterval string `toml:"check_interval"` // Go duration, e.g. "1h", "30m"
+	AutoApply     bool   `toml:"auto_apply"`
+}
+
+// Interval returns the parsed check interval, defaulting to 1h on parse error.
+func (c AutoUpdateConfig) Interval() time.Duration {
+	if c.CheckInterval == "" {
+		return 1 * time.Hour
+	}
+	d, err := time.ParseDuration(c.CheckInterval)
+	if err != nil {
+		log.Printf("auto_update: invalid check_interval %q, defaulting to 1h: %s", c.CheckInterval, err)
+		return 1 * time.Hour
+	}
+	if d < 5*time.Minute {
+		log.Printf("auto_update: check_interval %v too low, minimum is 5m", d)
+		return 5 * time.Minute
+	}
+	return d
+}
 
 type Config struct {
 	Listen   string       `toml:"listen"`
@@ -40,6 +66,7 @@ type TelemtConfig struct {
 	GithubRepo    string `toml:"github_repo"`
 	ConfigPath    string `toml:"config_path"`
 	ContainerName string `toml:"container_name"`
+	AutoUpdate    AutoUpdateConfig `toml:"auto_update"`
 }
 
 type PanelConfig struct {
@@ -48,6 +75,7 @@ type PanelConfig struct {
 	GithubRepo       string `toml:"github_repo"`
 	MaxNewerReleases int    `toml:"max_newer_releases"`
 	MaxOlderReleases int    `toml:"max_older_releases"`
+	AutoUpdate       AutoUpdateConfig `toml:"auto_update"`
 }
 
 type AuthConfig struct {
@@ -109,6 +137,10 @@ func Load(path string) (*Config, error) {
 	if cfg.Panel.GithubRepo == "" {
 		cfg.Panel.GithubRepo = "amirotin/telemt_panel"
 	}
+
+	// Validate auto-update intervals
+	_ = cfg.Telemt.AutoUpdate.Interval()
+	_ = cfg.Panel.AutoUpdate.Interval()
 
 	// Normalize base_path: ensure leading slash, strip trailing slash
 	cfg.BasePath = strings.TrimRight(cfg.BasePath, "/")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/telemt/telemt-panel/internal/auth"
+	"github.com/telemt/telemt-panel/internal/auto_update"
 	"github.com/telemt/telemt-panel/internal/config"
 	"github.com/telemt/telemt-panel/internal/geoip"
 	"github.com/telemt/telemt-panel/internal/logs"
@@ -280,6 +281,69 @@ func (s *Server) Run(version string, distFS fs.FS) error {
 
 	mux.Handle("GET /api/panel/update/status", auth.RequireAuth(jwtSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, jsonResponse{OK: true, Data: panelUpd.GetStatus()})
+	})))
+
+	// Auto-update manager
+	autoMgr := auto_update.New()
+	autoMgr.Register("panel", auto_update.Component{
+		CheckFn: func() (*auto_update.CheckResult, error) {
+			r, err := panelUpd.Check()
+			if err != nil {
+				return nil, err
+			}
+			return &auto_update.CheckResult{
+				CurrentVersion:  r.CurrentVersion,
+				LatestVersion:   r.LatestVersion,
+				UpdateAvailable: r.UpdateAvailable,
+				ReleaseName:     r.ReleaseName,
+				ReleaseURL:      r.ReleaseURL,
+				PublishedAt:     r.PublishedAt,
+				Changelog:       r.Changelog,
+			}, nil
+		},
+		ApplyFn: func(version string) error { return panelUpd.Apply(version) },
+	}, auto_update.ComponentConfig{
+		Enabled:       s.cfg.Panel.AutoUpdate.Enabled,
+		CheckInterval: s.cfg.Panel.AutoUpdate.CheckInterval,
+		AutoApply:     s.cfg.Panel.AutoUpdate.AutoApply,
+	})
+	autoMgr.Register("telemt", auto_update.Component{
+		CheckFn: func() (*auto_update.CheckResult, error) {
+			r, err := upd.Check()
+			if err != nil {
+				return nil, err
+			}
+			return &auto_update.CheckResult{
+				CurrentVersion:  r.CurrentVersion,
+				LatestVersion:   r.LatestVersion,
+				UpdateAvailable: r.UpdateAvailable,
+				ReleaseName:     r.ReleaseName,
+				ReleaseURL:      r.ReleaseURL,
+				PublishedAt:     r.PublishedAt,
+				Changelog:       r.Changelog,
+			}, nil
+		},
+		ApplyFn: func(version string) error { return upd.Apply(version) },
+	}, auto_update.ComponentConfig{
+		Enabled:       s.cfg.Telemt.AutoUpdate.Enabled,
+		CheckInterval: s.cfg.Telemt.AutoUpdate.CheckInterval,
+		AutoApply:     s.cfg.Telemt.AutoUpdate.AutoApply,
+	})
+	defer autoMgr.StopAll()
+
+	// Auto-update API
+	mux.Handle("GET /api/auto-update/status", auth.RequireAuth(jwtSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, jsonResponse{OK: true, Data: autoMgr.GetStatus()})
+	})))
+	mux.Handle("PUT /api/auto-update/config", auth.RequireAuth(jwtSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req auto_update.UpdateConfigRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid request body")
+			return
+		}
+		autoMgr.UpdateConfig("panel", req.Panel)
+		autoMgr.UpdateConfig("telemt", req.Telemt)
+		writeJSON(w, http.StatusOK, jsonResponse{OK: true, Data: autoMgr.GetStatus()})
 	})))
 
 	// Telemt service restart endpoint


### PR DESCRIPTION
## Summary

Closes #18

Adds per-component auto-update with configurable check intervals and optional auto-apply. Both Panel and Telemt can be independently configured to automatically check for new stable releases on GitHub and optionally install them.

### What's new

**Backend (`internal/auto_update/`):**
- `Manager` with per-component goroutines and `time.Ticker`
- Thread-safe state tracking: last check result, last check timestamp
- `GET /api/auto-update/status` — current config + last check results
- `PUT /api/auto-update/config` — update settings (takes effect immediately)
- Auto-apply only targets stable, non-downgrade releases
- Minimum interval: 5 minutes (clamped on parse)

**Config (`config.toml`):**
```toml
[panel.auto_update]
enabled = false
check_interval = "1h"   # Go duration: 5m, 30m, 1h, 6h, 24h
auto_apply = false       # risky: panel restart kills sessions

[telemt.auto_update]
enabled = false
check_interval = "1h"
auto_apply = true        # safe: Telemt has healthcheck + rollback
```

**Frontend (`UpdatePage.tsx`):**
- New "Автообновление" section at top of Update page
- Two cards: Panel, Telemt — each with:
  - Enable/disable toggle
  - Check interval dropdown (5m → 24h)
  - Auto-apply toggle
  - Last check time and result display
- Settings saved immediately via PUT API
- Russian UI strings matching existing convention

### Files changed

| File | Change |
|------|--------|
| `internal/auto_update/auto_update.go` | NEW — Manager, ComponentConfig, tickers |
| `internal/config/config.go` | Add `AutoUpdateConfig` struct + TOML fields |
| `internal/server/server.go` | Wire Manager + 2 API routes |
| `frontend/src/pages/UpdatePage.tsx` | AutoUpdateCard component |
| `frontend/src/lib/api.ts` | Add `put` method to panelApi |
| `config.example.toml` | Document new config sections |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/github/...` — pass
- [x] `tsc --noEmit` — clean
- [ ] Manual: enable auto-update, verify ticker starts in logs
- [ ] Manual: verify check interval updates take effect immediately
- [ ] Manual: verify auto-apply applies latest stable (not downgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)