### PR TITLE
fix: swap proxy share link copy buttons

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { LayoutDashboard, Users, Activity, Shield, Network, Settings, ArrowUpCircle, ScrollText, LogOut, X, Sun, Moon, Github } from 'lucide-react';
+import { LayoutDashboard, Users, Activity, Shield, Network, Settings, ArrowUpCircle, ScrollText, LogOut, X, Sun, Moon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '@/hooks/useTheme';
@@ -91,7 +91,7 @@ export function Sidebar({ isOpen = true, onClose }: SidebarProps) {
             rel="noopener noreferrer"
             className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover w-full transition-colors"
           >
-            <Github size={18} />
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65S8.93 17.38 9 18v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
             GitHub
           </a>
           <button

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -35,7 +35,7 @@ export function useWsProvider(): WsContextValue {
   const [errors, setErrors] = useState<ErrorMap>({});
   const [connected, setConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimer = useRef<ReturnType<typeof setTimeout>>();
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const subscribers = useRef<Map<string, Subscriber>>(new Map());
 
   const getAggregated = useCallback(() => {

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -343,8 +343,8 @@ export function UsersPage() {
                             <div className="flex flex-col gap-1">
                               {allLinks.map((link, i) => (
                                 <div key={i} className="flex items-center gap-1">
-                                  <CopyButton text={link.url} label={link.label} />
-                                  <CopyButton text={link.url.replace('tg://proxy', 'https://t.me/proxy')} label="t.me" />
+                                  <CopyButton text={link.url.replace('tg://proxy', 'https://t.me/proxy')} label={link.label} />
+                                  <CopyButton text={link.url} label="t.me" />
                                 </div>
                               ))}
                             </div>
@@ -441,8 +441,8 @@ export function UsersPage() {
                       <div className="text-xs text-text-secondary">Proxy Links</div>
                       {allLinks.map((link, i) => (
                         <div key={i} className="flex items-center gap-1">
-                          <CopyButton text={link.url} label={link.label} />
-                          <CopyButton text={link.url.replace('tg://proxy', 'https://t.me/proxy')} label="t.me" />
+                          <CopyButton text={link.url.replace('tg://proxy', 'https://t.me/proxy')} label={link.label} />
+                          <CopyButton text={link.url} label="t.me" />
                         </div>
                       ))}
                     </div>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "ignoreDeprecations": "6.0",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- Swap `CopyButton` text props in UsersPage so the proxy type button (TLS/Secure/Classic) copies the HTTPS `https://t.me/proxy?...` link and the "t.me" button copies the native `tg://proxy?...` protocol link
- Fix pre-existing TypeScript 6 compatibility issues blocking the pre-commit hook

## Test plan
- [ ] Open Users page, verify TLS button copies HTTPS link and t.me button copies tg:// link
- [ ] Verify mobile view (expanded user details) works the same
- [ ] Verify GitHub icon renders correctly in Sidebar

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)