### PR TITLE
fix join telemt group false positive

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,7 @@ join_telemt_group() {
   fi
 
   if [ -n "$_telemt_group" ] && [ "$_telemt_group" != "root" ]; then
-    if id -nG "$SYSTEM_USER" 2>/dev/null | grep -qw "$_telemt_group"; then
+    if id -nG "$SYSTEM_USER" 2>/dev/null | tr ' ' '\n' | grep -qx "$_telemt_group"; then
       say "User '$SYSTEM_USER' already in group '$_telemt_group'"
     else
       $SUDO usermod -aG "$_telemt_group" "$SYSTEM_USER" 2>/dev/null \


### PR DESCRIPTION
## Description

`join_telemt_group` в `install_panel.sh` некорректно определяла членство пользователя в группе. `grep -qw "telemt"` матчила строку `telemt-panel` (первичная группа пользователя), т.к. `-` является границей слова в grep. В результате функция считала `telemt-panel` уже состоящим в группе `telemt` и пропускала `usermod -aG`, из-за чего сервис запускался без нужных прав и не мог создавать backup-файлы в `/etc/telemt/`.

Исправлено через `tr ' ' '\n' | grep -qx` — список групп разбивается по одному на строку, затем ищется точное совпадение.

## Related Issues

Closes #66 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Checklist

- [x] Code follows project conventions (see `.github/instructions/`)
- [x] No secrets or credentials in code
- [ ] Go code: `gofmt` clean, errors wrapped with context
- [ ] New functionality has tests
- [ ] All existing tests pass (`go test ./...`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] Config changes are backward-compatible

## Testing

Проверено на тестовом сервере (Ubuntu 22.04):
1. Установлен telemt через [Telemt-Manager](https://github.com/DenisShahbazyan/Telemt-Manager)
2. Запущен `install_panel.sh` — в логе `Added 'telemt-panel' to group 'telemt'` (вместо `already in group`)
3. `/etc/group` подтверждает: `telemt:x:997:telemt-panel`
4. Редактирование конфига через веб-морду проходит без `permission denied`
