### PR TITLE
Change permissions of CONFIG_FILE from 600 to 660

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -394,7 +394,7 @@ do_install() {
     [ -n "${TELEMT_PATH:-}" ] || TELEMT_PATH=$(detect_telemt)
     [ -n "${TELEMT_SERVICE:-}" ] || TELEMT_SERVICE="telemt"
     $SUDO chown "$SYSTEM_USER:$SYSTEM_USER" "$CONFIG_FILE"
-    $SUDO chmod 600 "$CONFIG_FILE"
+    $SUDO chmod 660 "$CONFIG_FILE"
   else
     say "Setting up initial configuration..."
     echo ""


### PR DESCRIPTION
Change permissions of CONFIG_FILE from 600 to 660

## Description

Brief description of changes.

## Related Issues

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Checklist

- [ ] Code follows project conventions (see `.github/instructions/`)
- [ ] No secrets or credentials in code
- [ ] Go code: `gofmt` clean, errors wrapped with context
- [ ] New functionality has tests
- [ ] All existing tests pass (`go test ./...`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] Config changes are backward-compatible

## Testing

How was this tested? (visual verification on test server, unit tests, etc.)
